### PR TITLE
adjusting vertical alignment for Build Status row (mobile view)

### DIFF
--- a/src/components/MainTable.vue
+++ b/src/components/MainTable.vue
@@ -571,6 +571,10 @@
                 &.top {
                   @include shadow(inset 0 1px 1px 0 $ccc);
                 }
+
+                .build-details .status-badge {
+                  top: rem(-5);
+                }
               }
 
               @include mq('lg') {


### PR DESCRIPTION
@lixuna @taylor - Addressing this. 
<img width="502" alt="bug fixes - build status line allignment" src="https://user-images.githubusercontent.com/201141/33610966-7933f076-d992-11e7-98d8-8674d982d005.png">
