### PR TITLE
Promote GitLab URL to production

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -10,7 +10,7 @@
         </div>
 
         <div class="social-links">
-          <a class="social" href="http://github.com/crosscloudci" target="_blank"><i class="fa fa-github"></i></a>
+          <a class="social" href="http://github.com/crosscloudci/crosscloudci" target="_blank"><i class="fa fa-github"></i></a>
           <a class="social" href="http://twitter.com/crosscloudci" target="_blank"><i class="fa fa-twitter"></i></a>
           <a class="social" href="mailto:crosscloudci@vulk.coop"><i class="fa fa-envelope"></i></a>
         </div>


### PR DESCRIPTION
change cross-cloud link at the bottom of cncf.ci to be https://github.com/crosscloudci/crosscloudci