### PR TITLE
#111 remove "by Cross-Cloud CI" from footer

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -5,8 +5,6 @@
         <div class="built-by">
           <span>Created for</span>
           <a href="http://cncf.io" target="_blank">CNCF</a>
-          <span>by</span>
-          <a href="http://crosscloud.ci" target="_blank">Cross-Cloud CI</a>
         </div>
 
         <div class="social-links">


### PR DESCRIPTION
https://github.com/crosscloudci/crosscloudci/issues/111

Changes include:

* Remove “by Cross-Cloud CI” from footer
* keep “Created for CNCF”