### PR TITLE
#77 reverting back to png logo for CNCF

### DIFF
--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -4,7 +4,7 @@
       <header id="dashboard-header">
         <div id="dashboard-logo">
           <div class="cncf-logo" v-on:click="gotoURL()">
-            <img src="'https://raw.githubusercontent.com/cncf/artwork/master/cncf/horizontal/color/cncf-color.svg?sanitize=true'"/>
+            <img src="../assets/images/logo_cncf.png"/>
           </div>
         </div>
         <div id="dashboard-title">


### PR DESCRIPTION
#77 previous PR to replace png with svg was not successful. Reverting back to CNCF png until assistance is available.

Changes made: 
            <img src="../assets/images/logo_cncf.png"/>