### PR TITLE
#139 Project view on mobile remains expanded on subsequent visits.

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -8,8 +8,8 @@
         </div>
 
         <div class="social-links">
-          <a class="social" href="http://github.com/crosscloudci/ci-dashboard" target="_blank"><i class="fa fa-github"></i></a>
-          <a class="social" href="http://twitter.com/crosscloudci" target="_blank"><i class="fa fa-twitter"></i></a>
+          <a class="social" href="https://github.com/crosscloudci/ci-dashboard" target="_blank"><i class="fa fa-github"></i></a>
+          <a class="social" href="https://twitter.com/cncfci" target="_blank"><i class="fa fa-twitter"></i></a>
           <a class="social" href="mailto:cncfci@vulk.coop"><i class="fa fa-envelope"></i></a>
         </div>
 


### PR DESCRIPTION
https://github.com/crosscloudci/crosscloudci/issues/139

Project view on mobile remains expanded on subsequent visits:
- works for Stable GitHub link, Head GitHub link, Build status badges and Deploy status badges

A/C passes on staging: 

On mobile:

1. Go to x.cncf.ci
2. The default Test environment shows Kubernetes Stable option (no change)
3. I can click on a project. Eg. CoreDNS to see expanded view (no change)
4. I can click on Stable / Head / Success badge (no change)
5. Clicking on button opens a new tab for the URL (no change)
6. Upon closing this tab, returning to the previous screen, I would expect to still see the same expanded view (eg for CoreDNS) as I did before clicking on Stable / Head / Success badge

LGTM
